### PR TITLE
Optionally add certs

### DIFF
--- a/scripts/4_addTrustCerts.sh
+++ b/scripts/4_addTrustCerts.sh
@@ -8,7 +8,7 @@ source ./commons.sh
 addTrustCerts()
 {
   TRUST_CERTS=`cf target | grep "api endpoint" | cut -d" " -f5| xargs`
-  cf set-env $1 TRUST_CERTS TRUST_CERTS
+  cf set-env $1 TRUST_CERTS $TRUST_CERTS
   cf restage $1 &
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,8 +10,11 @@ If you want ultimate simplicity just run:
 
 ``` ./doItAll.sh ```
 
-This will delete previous app instances, previous service instances, re-create the services, build and push the apps (and activate certificates with Spring Cloud Services).
+This will delete previous app instances, previous service instances, re-create the services, build and push the apps (and activate certificates with Spring Cloud Services).  If you are using self-signed certs you will need to add the ```add-certs``` option:  
 
+``` ./doItAll.sh add-certs ```
+
+See the 4_addTrustCerts.sh section below for more details.
 ## Scripts to deploy in three steps
 These scripts are numbered, just run them in the logical order of numbering from script 1 all the way to the last script  :)
 
@@ -39,14 +42,14 @@ To execute simply run:
 
 ``` ./3_deploy.sh ```
 
-### 4_addTarget.sh
+### 4_addTrustCerts.sh
 This step is only necessary if you are running in a PCF environment which <a href="https://docs.pivotal.io/spring-cloud-services/service-registry/writing-client-applications.html" target="_blank">uses self-signed certificates</a>.  If you are not on such a PCF environment, don't run this step.
 
 The script is necessary to make your Microservices register with Eureka in Service Discovery, if you are using self-signed certs and do not run it, then none of your Microservices will Register in Service Discovery even though they have bound to the service. It also uses the ```microServices.list``` file.
 
 To execute simply run:
 
-``` ./4_addTarget.sh ```
+``` ./4_addTrustCerts.sh ```
 
 ## Scripts to delete the apps and services
 

--- a/scripts/doItAll.sh
+++ b/scripts/doItAll.sh
@@ -26,7 +26,9 @@ wait
 sh ./1_createServices.sh
 sh ./2_build.sh
 sh ./3_deploy.sh
-sh ./4_addTrustCerts.sh
+if [ "$0" = "add-certs" ]; then
+  sh ./4_addTrustCerts.sh
+fi
 
 echo "Executed $SCRIPTNAME in $SECONDS seconds."
 exit 0


### PR DESCRIPTION
When running the doItAll script, you would always add certs whether that was necessary or not (e.g. PWS).  It is now optional.